### PR TITLE
add date type

### DIFF
--- a/chisel/__init__.py
+++ b/chisel/__init__.py
@@ -37,6 +37,7 @@ DocPage = _doc.DocPage
 
 from . import model as _model
 
+JsonDate = _model.JsonDate
 JsonDatetime = _model.JsonDatetime
 JsonFloat = _model.JsonFloat
 JsonUUID = _model.JsonUUID

--- a/chisel/spec.py
+++ b/chisel/spec.py
@@ -22,7 +22,7 @@
 
 from .compat import StringIO
 from .model import AttributeValidationError, StructMemberAttributes, TypeArray, TypeBool, \
-    TypeDatetime, Typedef, TypeDict, TypeEnum, TypeInt, TypeFloat, TypeString, TypeStruct, TypeUuid
+    TypeDate, TypeDatetime, Typedef, TypeDict, TypeEnum, TypeInt, TypeFloat, TypeString, TypeStruct, TypeUuid
 
 import re
 
@@ -103,6 +103,7 @@ class SpecParser(object):
         'int': TypeInt,
         'float': TypeFloat,
         'bool': TypeBool,
+        'date': TypeDate,
         'datetime': TypeDatetime,
         'uuid': TypeUuid,
         }

--- a/chisel/tests/test_doc.py
+++ b/chisel/tests/test_doc.py
@@ -94,6 +94,7 @@ struct MyStruct
     MyStruct{} member9
     MyEnum : MyStruct{len > 0} member10
     string(len == 2) : int(> 5){len > 0} member11
+    date member12
 
 # An unused struct
 # My Union
@@ -654,6 +655,17 @@ My float member
             <li><span class="chsl-emphasis">len(dict)</span> &gt; 0</li>
             <li><span class="chsl-emphasis">len(key)</span> == 2</li>
             <li><span class="chsl-emphasis">elem</span> &gt; 5</li>
+          </ul>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>member12</td>
+        <td>date</td>
+        <td>
+          <ul class="chsl-constraint-list">
+            <li><span class="chsl-emphasis">none</span></li>
           </ul>
         </td>
         <td>

--- a/chisel/tests/test_spec.py
+++ b/chisel/tests/test_spec.py
@@ -107,6 +107,7 @@ struct MyStruct2
     optional datetime h
     optional uuid i
     optional MyEnum : MyStruct{} j
+    optional date k
 
 # This is a union
 union MyUnion
@@ -136,6 +137,7 @@ action MyAction3
     output
         int a
         datetime b
+        date c
 
 # The fourth action
 action MyAction4
@@ -166,7 +168,8 @@ action MyAction4
                                  ('g', chisel.model.TypeDict, True),
                                  ('h', chisel.model._TypeDatetime, True),
                                  ('i', chisel.model._TypeUuid, True),
-                                 ('j', chisel.model.TypeDict, True)))
+                                 ('j', chisel.model.TypeDict, True),
+                                 ('k', chisel.model._TypeDate, True)))
         self.assertStructByName(parser, 'MyUnion',
                                 (('a', chisel.model._TypeInt, True),
                                  ('b', chisel.model._TypeString, True)))
@@ -195,7 +198,8 @@ action MyAction4
         self.assertAction(parser, 'MyAction3',
                           (),
                           (('a', chisel.model._TypeInt, False),
-                           ('b', chisel.model._TypeDatetime, False)),
+                           ('b', chisel.model._TypeDatetime, False),
+                           ('c', chisel.model._TypeDate, False)),
                           ())
         self.assertAction(parser, 'MyAction4',
                           (),

--- a/chisel/tests/test_url.py
+++ b/chisel/tests/test_url.py
@@ -23,7 +23,7 @@
 from chisel import decodeQueryString, encodeQueryString, tzutc
 from chisel.compat import PY3
 
-from datetime import datetime
+from datetime import date, datetime
 import unittest
 from uuid import UUID
 
@@ -241,6 +241,13 @@ class TestUrl(unittest.TestCase):
 
         o = { 'a': True }
         s = 'a=true'
+        self.assertEqual(encodeQueryString(o), s)
+
+    # Test date query string encoding
+    def test_url_encodeQueryString_date(self):
+
+        o = { 'a': date(2013, 7, 18) }
+        s = 'a=2013-07-18'
         self.assertEqual(encodeQueryString(o), s)
 
     # Test datetime query string encoding

--- a/chisel/url.py
+++ b/chisel/url.py
@@ -21,12 +21,12 @@
 #
 
 from .compat import basestring_, PY3, urllib, xrange_
-from .model import JsonDatetime, JsonUUID
+from .model import JsonDate, JsonDatetime, JsonUUID
 
 urllib_quote = urllib.quote
 urllib_unquote = urllib.unquote
 
-from datetime import datetime
+from datetime import date, datetime
 from uuid import UUID
 
 
@@ -68,7 +68,9 @@ def encodeQueryString(o, encoding = 'utf-8'):
             elif not topLevel:
                 yield (parent, '')
         else:
-            if isinstance(o, datetime):
+            if isinstance(o, date):
+                ostr = str(JsonDate(o)).strip('"')
+            elif isinstance(o, datetime):
                 ostr = str(JsonDatetime(o)).strip('"')
             elif isinstance(o, UUID):
                 ostr = str(JsonUUID(o)).strip('"')


### PR DESCRIPTION
This would be useful in my billing scenarios where I have inputs and outputs that are semantically date-only. Although datetime can be used, inputs have to be documented to indicate that time and timezone offset are ignored, and the conversion-to-utc that chisel provides has to be undone to recover the original date specified by the client. For outputs, including a time and timezone offset bloats the payload, especially in scenarios like billing where hundreds of rows are being returned, and the client has to be sure to ignore the time and timezone information.
